### PR TITLE
ci package: use ubuntu-24.04 as a runner image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -148,7 +148,7 @@ jobs:
           # - pgroonga-fedora-33
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GitHub: ref [GH-507](https://github.com/pgroonga/pgroonga/issues/507)

Updating GitHub Actions runner images to Ubuntu 24.04 allows us to use Incus package.

ref: https://packages.ubuntu.com/search?searchon=sourcenames&keywords=incus